### PR TITLE
Add motorised fiber paddle-based polarization compensation

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,8 @@
+files: ^S15qkd/modules/polcomp/
+repos:
+- repo: https://github.com/astral-sh/ruff-pre-commit
+  rev: v0.7.1
+  hooks:
+    - id: ruff
+      args: [ --fix ]
+    - id: ruff-format

--- a/README.md
+++ b/README.md
@@ -44,3 +44,15 @@ It ties together the quantum channel and the classical channel and generates enc
 The general design for QKD server (together with the underlying qcrypto stack) is illustrated below, current as of commit `b2443f0`:
 
 ![](docs/qkdserver_schematic.png)
+
+## Contributing
+
+Linting services are provided by [Ruff](https://github.com/astral-sh/ruff) using [pre-commit](https://pre-commit.com/). This will eventually be rolled out gradually throughout the entire codebase - no CI linting is currently performed to minimize disruption. To run the linter:
+
+```bash
+pip3 install pre-commit
+pre-commit install
+pre-commit run  # ad-hoc
+```
+
+The scope of linting can be modified in the `.pre-commit-config.yaml` configuration to use the **files** and **exclude** [keys](https://pre-commit.com/#new-hooks). Commit changes to the configuration before `pre-commit` can be run again.

--- a/S15qkd/configs/qkd_engine_config.default.json
+++ b/S15qkd/configs/qkd_engine_config.default.json
@@ -75,6 +75,7 @@
       "frequency_search": false
     },
     "polarization_compensation": {
+      "use_mpc320_device": false,
       "target_qber": 0.05,
       "loss_exponent": 1.5,
       "loss_coefficient": 8.5,

--- a/S15qkd/configs/qkd_engine_config.default.json
+++ b/S15qkd/configs/qkd_engine_config.default.json
@@ -88,6 +88,9 @@
       "averaging_length": 3,
       "separation_length": 12,
       "limit_correction": 1e-9
+    },
+    "error_correction": {
+      "report_start_epoch": false
     }
   },
   "ENVIRONMENT": {

--- a/S15qkd/controller.py
+++ b/S15qkd/controller.py
@@ -47,7 +47,7 @@ from .readevents import Readevents
 from .pfind import Pfind
 from .utils import Process, read_T2_header, HeadT2, get_current_epoch, epoch_after
 from .error_correction import ErrorCorr
-from .polarization_compensation import PolComp, MockPolComp, PaddlePolComp
+from .polarization_compensation import PolComp
 
 # Own modules
 from . import qkd_globals

--- a/S15qkd/controller.py
+++ b/S15qkd/controller.py
@@ -48,6 +48,7 @@ from .pfind import Pfind
 from .utils import Process, read_T2_header, HeadT2, get_current_epoch, epoch_after
 from .error_correction import ErrorCorr
 from .polarization_compensation import PolComp
+from S15qkd.modules.polcomp.paddles.paddlepolcomp import PaddlePolComp
 
 # Own modules
 from . import qkd_globals
@@ -102,7 +103,10 @@ class Controller:
         self.restart_authd()
 
         if Process.config.LCR_polarization_compensator_path != "":
-            self.polcom = PolComp(Process.config.LCR_polarization_compensator_path, self.service_to_BBM92)
+            if Process.config.qcrypto.polarization_compensation.use_mpc320_device:
+                self.polcom = PaddlePolComp(Process.config.LCR_polarization_compensator_path, self.service_to_BBM92)
+            else:
+                self.polcom = PolComp(Process.config.LCR_polarization_compensator_path, self.service_to_BBM92)
             if Process.config.do_polarization_compensation:
                 self.do_polcom = True
             else:

--- a/S15qkd/error_correction.py
+++ b/S15qkd/error_correction.py
@@ -212,7 +212,12 @@ class ErrorCorr(Process):
             self.QBER_servo_history.clear()
             self._callback_qber_exceed()
         else:
-            self._callback_pol_comp(qber=self.ec_err_fraction,epoch=epoch_after(self._ec_epoch,int(self._ec_nr_of_epochs,10)))
+            if Process.config.qcrypto.error_correction.report_start_epoch:
+                epoch = self._ec_epoch
+            else:
+                # Report the last epoch in the error correction instead (default)
+                epoch = epoch_after(self._ec_epoch, int(self._ec_nr_of_epochs, 10))
+            self._callback_pol_comp(qber=self.ec_err_fraction, epoch=epoch)
 
         try:
             1+1

--- a/S15qkd/modules/polcomp/mock/mockpolcomp.py
+++ b/S15qkd/modules/polcomp/mock/mockpolcomp.py
@@ -1,18 +1,22 @@
 #!/usr/bin/env python3
 """Provides the MockPolComp class."""
 
-import fpfind.lib.parse_epochs as parser
+import time
+
 from S15qkd import qkd_globals
 from S15qkd.modules.polcomp.qber_estimator import QberEstimator
+
 
 class MockPolComp:
     """Enumerates interface exposed to Controller."""
 
-    def __init__(self, lcr_path, callback_service_to_BBM92=None):  # Controller.__init__()
+    def __init__(
+        self, lcr_path, callback_service_to_BBM92=None
+    ):  # Controller.__init__()
         self._callback = callback_service_to_BBM92
         self.estimator = QberEstimator()
         self.qber = self.estimator.qber
-        self.qber_threshold = qkd_globals.config['QBER_threshold']
+        self.qber_threshold = qkd_globals.config["QBER_threshold"]
 
     def send_epoch(self, epoch):  # Controller.send_epoch_notification()
         """Process notification of epoch provided by costream/splicer.
@@ -43,6 +47,7 @@ class MockPolComp:
     def last_qber(self) -> float:  # Controller.get_status_info()
         return self.qber
 
+
 class ProxyPolComp(MockPolComp):
     """Proxies the QBER information to a writable file, for handling by other interfaces."""
 
@@ -68,9 +73,10 @@ class ProxyPolComp(MockPolComp):
         qber = float(qber)
         return qber, epoch
 
-    def _read_qber_after(epoch):
+    def _read_qber_after(self, epoch):
         """Monitors and returns the QBER after specified epoch."""
         from fpfind.lib import parse_epochs as parser
+
         epochint = parser.epoch2int(epoch)
         while True:
             qber, _epoch = self._read_qber()

--- a/S15qkd/modules/polcomp/mock/mockpolcomp.py
+++ b/S15qkd/modules/polcomp/mock/mockpolcomp.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Provides the MockPolComp class."""
+
+import fpfind.lib.parse_epochs as parser
+from S15qkd import qkd_globals
+from S15qkd.modules.polcomp.qber_estimator import QberEstimator
+
+class MockPolComp:
+    """Enumerates interface exposed to Controller."""
+
+    def __init__(self, lcr_path, callback_service_to_BBM92=None):  # Controller.__init__()
+        self._callback = callback_service_to_BBM92
+        self.estimator = QberEstimator()
+        self.qber = self.estimator.qber
+        self.qber_threshold = qkd_globals.config['QBER_threshold']
+
+    def send_epoch(self, epoch):  # Controller.send_epoch_notification()
+        """Process notification of epoch provided by costream/splicer.
+
+        Responsible for extracting QBER and calling SERVICE->BBM92.
+        """
+        self.qber = self.estimator.handle_epoch(epoch)
+        if self.qber < self.qber_threshold:
+            self._callback()
+
+    def update_QBER_secure(self, qber, epoch):  # Controller.drift_secure_comp()
+        """Process notification of QBER @ epoch provided by error correction.
+
+        Direct counterpart to PolComp.send_epoch().
+        """
+        self.qber = qber
+
+    def start_walk(self):  # Controller.pol_com_walk()
+        pass
+
+    def save_config(self):  # Controller.reload_configuration()
+        pass
+
+    def load_config(self):  # Controller.reload_configuration()
+        pass
+
+    @property
+    def last_qber(self) -> float:  # Controller.get_status_info()
+        return self.qber
+
+class ProxyPolComp(MockPolComp):
+    """Proxies the QBER information to a writable file, for handling by other interfaces."""
+
+    READOUT_FILE = "/tmp/cryptostuff/mockpolcomp_qber_epoch.txt"
+
+    def send_epoch(self, epoch):
+        super().send_epoch(epoch)
+        self._write_qber(self.qber, epoch)
+
+    def update_QBER_secure(self, qber, epoch):
+        super().update_QBER_secure(qber, epoch)
+        self._write_qber(qber, epoch)
+
+    def _write_qber(self, qber, epoch):
+        """Writes QBER and corresponding epoch to temporary file for message passing."""
+        with open(ProxyPolComp.READOUT_FILE, "w") as f:
+            f.write(f"{qber} {epoch}")
+
+    def _read_qber(self):
+        with open(ProxyPolComp.READOUT_FILE) as f:
+            data = f.read()
+        qber, epoch = data.strip().split(" ")
+        qber = float(qber)
+        return qber, epoch
+
+    def _read_qber_after(epoch):
+        """Monitors and returns the QBER after specified epoch."""
+        from fpfind.lib import parse_epochs as parser
+        epochint = parser.epoch2int(epoch)
+        while True:
+            qber, _epoch = self._read_qber()
+            _epochint = parser.epoch2int(_epoch)
+            if _epochint > epochint:
+                return qber
+            time.sleep(0.5)  # wait for next epoch

--- a/S15qkd/modules/polcomp/mock/mockpolcomp.py
+++ b/S15qkd/modules/polcomp/mock/mockpolcomp.py
@@ -49,7 +49,7 @@ class MockPolComp:
 
 
 class ProxyPolComp(MockPolComp):
-    """Proxies the QBER information to a writable file, for handling by other interfaces."""
+    """Proxies QBER information to writable file, for handling by other interfaces."""
 
     READOUT_FILE = "/tmp/cryptostuff/mockpolcomp_qber_epoch.txt"
 

--- a/S15qkd/modules/polcomp/optimizers.py
+++ b/S15qkd/modules/polcomp/optimizers.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python
+"""Holds optimization routines for polarization compensation."""
+
+import multiprocessing
+
+import scipy.optimize
+import numpy as np
+
+
+def run_manual_optimizer(optimizer, args=(), kwargs={}):
+    """Starts optimizer in a separate process and retuns a manual callback.
+
+    Note that optimizer termination is signaled by raising of 'StopIteration' exception,
+    so this needs to be wrapped in a try-except. Since the optimizer uses manual callbacks, the args and kwargs should not be populated with the first parameter 'f' of the optimizer.
+
+    Note:
+        Rather than letting the optimizer push a configuration change and poll
+        for measurement results, we instead reverse it: measurement results are
+        pushed to the optimizer, which in turn recommends a new configuration.
+        This effectively decouples the optimizer from the polarization
+        compensation execution thread, much like the existing architecture in QKDServer.
+    """
+    # Create duplex pipe for sending/receiving results from the optimizer
+    parent_conn, child_conn = multiprocessing.Pipe()
+
+    # Wrap child connection for use in optimizer
+    def f(x):
+        child_conn.send(x)
+        y = child_conn.recv()
+        if y is None:
+            child_conn.close()
+            raise StopIteration
+        return y
+
+    args = (f,) + tuple(args)
+    if "f" in kwargs:
+        raise ValueError("Keyword 'f' is disabled.")
+    p = multiprocessing.Process(target=optimizer, args=args, kwargs=kwargs, daemon=True)
+    p.start()
+
+    # Wrap parent connection in a simple function
+    parent_conn.recv()  # discard initial bootstrapped value, i.e. equal to x0
+
+    def result_callback(y):
+        parent_conn.send(y)
+        if y is None:
+            parent_conn.close()
+            return
+        return parent_conn.recv()
+
+    return result_callback
+
+
+def minimize_neldermead(f, x0, step, bounds):
+    """Runs Nelder-Mead minimizer with callback."""
+    simplex = generate_simplex(x0, step, bounds)
+    x0 = simplex[0]  # applied clipping
+    options = {"initial_simplex": simplex}
+    try:
+        scipy.optimize.minimize(
+            f,
+            x0,
+            bounds=bounds,
+            method="Nelder-Mead",
+            options=options,
+        )
+    except StopIteration:
+        pass
+
+
+def generate_simplex(vertex, step=1, bounds=[]):
+    """Returns a simplex with origin vertex, and unit step in each dimension.
+
+    This provides an initial search area for the Nelder-Mead algorithm.
+    If 'step' is an array, it should match the dimension of the provided
+    origin vertex, otherwise it should be single-valued for broadcasting to
+    the shape of the vertex. If 'bounds' is provided, it should be an array
+    of 2-tuples representing the minimum and maximum for each dimension.
+
+    The 'step' applied is considered independent of polarity, i.e. a step in
+    the negative direction is also valid. Extra bound checking is performed
+    to choose steps for each dimension so that the number of boundary clips
+    needed is minimized.
+
+    Usage:
+        >>> generate_simplex([0,1], 2).astype(int).tolist()
+        [[0, 1], [2, 1], [0, 3]]
+
+        >>> generate_simplex([1,1,1], [1,2,3]).astype(int).tolist()
+        [[1, 1, 1], [2, 1, 1], [1, 3, 1], [1, 1, 4]]
+
+        # The simplex before clippping is [(0,1), (2,1), (0,3)]
+        >>> generate_simplex([0,1], 2, bounds=[(0,1),(0,1)]).astype(int).tolist()
+        [[0, 1], [1, 1], [0, 1]]
+
+        # The last point transforms to (0,2) and (0,0) for positive and negative
+        # step respectively. Since (0,2) -> (0,1) requires one clip while (0,0) does
+        # not, the negative step is preferentially chosen. If the number of clips
+        # needed is the same, the positive step is the default.
+        >>> generate_simplex([0,1], 1, bounds=[(0,1),(0,1)]).astype(int).tolist()
+        [[0, 1], [1, 1], [0, 0]]
+    """
+    vertex = np.array(vertex)
+    assert vertex.ndim == 1
+    d = vertex.size
+
+    # Generate simplex with origin and unit step in each dimension
+    unit_simplex = np.vstack(
+        [
+            np.zeros(d),
+            np.identity(d),
+        ]
+    )
+    step = np.array(step)
+    assert step.ndim == 0 or step.shape == (d,)
+    simplex = unit_simplex * step + vertex  # scale + translate
+    simplex2 = unit_simplex * -step + vertex  # inverted steps
+
+    # Apply boundary conditions
+    if bounds:
+        bounds = np.array(bounds)
+        assert bounds.shape == (d, 2)
+
+        # Perform clipping
+        _simplex = np.clip(simplex, *bounds.T)
+        _simplex2 = np.clip(simplex2, *bounds.T)
+
+        # Try to minimize amount of correction
+        corr = np.sum(np.abs(_simplex - simplex), axis=1)
+        corr2 = np.sum(np.abs(_simplex2 - simplex2), axis=1)
+        cond = corr <= corr2
+        cond = np.broadcast_to(
+            cond, (d, d + 1)
+        ).T  # workaround for selecting/rejecting entire points
+        simplex = np.where(cond, _simplex, _simplex2)
+
+    return simplex

--- a/S15qkd/modules/polcomp/optimizers.py
+++ b/S15qkd/modules/polcomp/optimizers.py
@@ -3,15 +3,17 @@
 
 import multiprocessing
 
-import scipy.optimize
 import numpy as np
+import scipy.optimize
 
 
 def run_manual_optimizer(optimizer, args=(), kwargs={}):
     """Starts optimizer in a separate process and retuns a manual callback.
 
     Note that optimizer termination is signaled by raising of 'StopIteration' exception,
-    so this needs to be wrapped in a try-except. Since the optimizer uses manual callbacks, the args and kwargs should not be populated with the first parameter 'f' of the optimizer.
+    so this needs to be wrapped in a try-except. Since the optimizer uses manual
+    callbacks, the args and kwargs should not be populated with the first parameter 'f'
+    of the optimizer.
 
     Note:
         Rather than letting the optimizer push a configuration change and poll

--- a/S15qkd/modules/polcomp/paddles/mpc320.py
+++ b/S15qkd/modules/polcomp/paddles/mpc320.py
@@ -15,11 +15,11 @@ Changelog:
     2024-10-17 Justin: Standardize conventions
 """
 
-import numpy as np
-import serial
 import time
 import warnings
 
+import numpy as np
+import serial
 import thorlabs_apt_protocol as _apt
 
 
@@ -248,7 +248,7 @@ class ThorlabsMPC320:
         ignored, since similar functionality is achieved by actually
         querying the motor directly.
         """
-        resp = [msg for msg in self.reader]
+        resp = list(self.reader)
 
         # Filter status update responses
         status = ["mot_move_completed", "mot_move_stopped", "mot_move_homed"]
@@ -368,7 +368,7 @@ class ThorlabsMPC320:
         if hasattr(obj, "__len__"):  # object is already a tuple
             if len(obj) != 3:
                 raise ValueError("Tuple needs to be of length 3.")
-            if t is not None and not all([isinstance(v, t) for v in obj]):
+            if t is not None and not all(isinstance(v, t) for v in obj):
                 raise ValueError(f"Tuple is not of type '{t}': '{obj}'")
             obj = tuple(obj)
         else:
@@ -462,8 +462,8 @@ class ThorlabsMPC320:
 
 class Apt:
     """
-    See Thorlabs APT protocol specification, page 12, for description of dest and source.
-    Used when messages are broadcasted to sub-modules.
+    See Thorlabs APT protocol specification, page 12, for description of
+    dest and source. Used when messages are broadcasted to sub-modules.
     In modern systems, typically connect one-to-one COM port connection,
     so can simply replace all source reference to 0x01 (host) and
     destination reference to 0x50 (generic USB).

--- a/S15qkd/modules/polcomp/paddles/mpc320.py
+++ b/S15qkd/modules/polcomp/paddles/mpc320.py
@@ -1,0 +1,510 @@
+#!/usr/bin/env python3
+"""Controls the Thorlabs MPC320 motorized polarization controller.
+
+Communicates with Thorlabs MPC320 motorized polarization controller directly,
+without use of Windows-dependent 'APT.dll' required in 'thorlabs-apt' library.
+This allows Linux platforms to interact with the motor.
+
+Uses 'thorlabs_apt_protocol' for generating and reading messages.
+Documentation for APT protocol can be found in:
+https://www.thorlabs.com/Software/Motion%20Control/APT_Communications_Protocol.pdf
+
+Changelog:
+    2022-07-19 Justin: Initialize base Thorlabs APT class
+    2023-02-15 Syed: Modify code for Thorlabs MPC320 controller
+    2024-10-17 Justin: Standardize conventions
+"""
+
+import math
+import numpy as np
+import serial
+import time
+import warnings
+
+import thorlabs_apt_protocol as _apt
+
+class ThorlabsMPC320:
+    """Wrapper for APT commands relevant to MPC320."""
+
+    CHANNELS = [1, 2, 4]  # index to actual channel number
+    MIN_RANGE = 1.5
+    MAX_RANGE = 159
+    FULL_REV = 170
+    STEPS_PER_REVOLUTION = 1370
+    MIN_STEP = FULL_REV / STEPS_PER_REVOLUTION
+
+    def __init__(self, port, blocking=True, homed=False):
+        """Creates the motor instance.
+
+        If blocking is set to 'True', both homing and moving
+        commands will block until completion.
+
+        Important: Ensure that the homing parameter 'offset_position'
+        is correct for your stage.
+
+        Usage:
+            >>> motor = ThorlabsMPC320("/dev/serial/by-id/...")
+            >>> motor.angles
+            (83.94, 83.94, 83.94)
+            >>> motor.channel = 0
+            >>> motor.angle = 0
+            >>> motor.channel = 1
+            >>> motor.angle = 45
+            >>> motor.channel = 2
+            >>> motor.angle = 90
+            >>> motor.angles
+            (4.59, 48.15, 93.07)
+        """
+        self._com = serial.Serial(
+            port=port,
+            baudrate=115200,
+            rtscts=True,
+            timeout=0.1,
+        )
+
+        # Enable RTS control flow (technically not needed)
+        # and reset input/output buffers
+        self._com.rts = True
+        self._com.reset_input_buffer()
+        self._com.reset_output_buffer()
+        self._com.rts = False
+
+        # Enable channels
+        self.enabled = True
+
+        # Reader for device output - unpacks messages
+        self.reader = apt.Unpacker(self._com)
+
+        # Device constants
+        self.steps_per_revolution = 1370
+        self.min_range = self.MIN_RANGE
+        self.max_range = self.MAX_RANGE
+        self.min_step = self.FULL_REV / self.steps_per_revolution
+        self.blocking = blocking
+        self.offset = [989, 989, 989]
+
+        # Required initialization as per APT protocol
+        #self.w(_apt.hw_no_flash_programming(dest=0x50,source=0x01))
+
+        # Initialize device defaults, defined below in 'Parameters'
+        self.params_velocity = {}
+        self.params_jog = {}
+        self.params_homing = {}  # important: check homing offset
+
+        if not homed:
+            time.sleep(0.5)  # give the controller some time to initialize itself
+            for ch in range(len(self.CHANNELS)):
+                self.channel = ch
+                self.home()
+
+        # Set default channel
+        self.channel = 0
+
+    ################
+    #   COMMANDS   #
+    ################
+
+    # Most usage will only require interfacing via these commands.
+    #   For customizing operating parameters, see 'Parameters' section.
+    #   For direct interfacing with motor, see 'Helper' section.
+
+    @property
+    def identity(self) -> int:
+        """Returns serial number of motor.
+
+        Note that Thorlabs software typically distinguish devices
+        by serial number.
+        """
+        return self.rw(apt.hw_req_info()).serial_number
+
+    def home(self):
+        """Requests motor to go to home based on homing parameters."""
+        self.w(apt.mot_move_home(chan_ident=self._channel))
+        if self.blocking:
+            while self.is_moving(): pass
+
+    def stop(self, abrupt=False):
+        """Stops motor movement."""
+        stop_mode = 0x1 if abrupt else 0x2
+        self.w(apt.mot_move_stop(chan_ident=self._channel, stop_mode=stop_mode))
+
+    @property
+    def channel(self):
+        return self.CHANNELS.index(self._channel)
+
+    @channel.setter
+    def channel(self, v):
+        if not isinstance(v, int):
+            raise TypeError(f"Channel supplied is not an integer: '{v}'")
+        num_channels = len(self.CHANNELS)
+        if not 0 <= v < num_channels:
+            raise ValueError(f"Channel supplied is not one of {set(range(num_channels))}")
+        self._channel = self.CHANNELS[v]
+
+    @property
+    def angle(self) -> float:
+        """Returns angular position in degrees."""
+        return round(self.position * self.min_step, 2)
+
+    @angle.setter
+    def angle(self, angle: float):
+        """Sets angular position of current channel, in degrees."""
+        angle = self.validate_angle(angle)
+        self.goto(self._channel, self.deg2pos(angle))
+        if self.blocking:
+            while self.is_moving(): pass
+
+    @property
+    def angles(self) -> list:
+        """Returns angular positions of all channels in degrees."""
+        _channel = self.channel
+        angles = []
+        for channel in range(len(self.CHANNELS)):
+            self.channel = channel
+            angles.append(self.angle)
+        self.channel = _channel
+        return tuple(angles)
+
+    @angles.setter
+    def angles(self, angles):
+        """Sets angular positions of all channels in degrees.
+
+        If None is passed, then the channel is ignored.
+
+        Note:
+            There is no need to specially disable blocking mode, since
+            the motor controller processes the angle rotations in a
+            sequential manner anyway.
+        """
+        _channel = self.channel
+        angles = self.validate_3tuple(angles)
+        for channel, angle in enumerate(angles):
+            if angle is None:
+                continue
+            self.channel = channel
+            self.angle = angle
+        self.channel = _channel
+
+    def scan(self, start=10, end=90, scan_step=1, channel=None):
+        """Performs an angle scan on the current channel.
+
+        Usage:
+            >>> for angle in motor.scan(45, 135, 0.5):
+            ...     result = get_result(angle)
+        """
+        start = self.validate_angle(start)
+        end = self.validate_angle(end)
+        scan_step = max(scan_step, self.min_step)
+        scan_angles = np.arange(start, end, scan_step)  # TODO: Floating point errors will occur
+
+        # Mainloop
+        for angle in scan_angles:
+            if channel is not None:
+                _channel = self.channel
+                self.channel = channel
+            self.angle = angle
+            if channel is not None:
+                self.channel = _channel
+            yield angle
+
+
+    ########################
+    #   HELPER FUNCTIONS   #
+    ########################
+
+    # Note: Forward corresponds to counter-clockwise rotation, so
+    #       reverse corresponds to clockwise rotation.
+    #
+    # There are 1370 microsteps per 160 degree.
+    #
+    # Initial settings via Kinesis sets:
+    # - Homing: Reverse direction with hardware reverse limit switch
+    #           Zero offset = 4.0deg, velocity = 10.0deg/s
+    # - Hardware limit switch: CCW makes (home), CW ignore.
+    # - Software limit switch policy: Complete moves only
+    # - Motor: Steps/revolution 200, gearbox ratio 120:1
+    # - Backlash: 1deg
+
+    def w(self, command: bytes):
+        """Writes byte command to motor."""
+        self._com.write(command)
+
+    def r(self):
+        """Reads from motor.
+
+        As far as possible, we want to keep only a single message in buffer,
+        for ease of debugging, and since use cases for multiple REQs before
+        a single GET is rare, e.g. high resolution motor positioning.
+
+        If multiple messages exist, a warning is raised and only the latest
+        message is returned.
+
+        Note that the status update messages pushed by the motor is generally
+        ignored, since similar functionality is achieved by actually
+        querying the motor directly.
+        """
+        resp = [msg for msg in self.reader]
+
+        # Filter status update responses
+        status = ["mot_move_completed", "mot_move_stopped", "mot_move_homed"]
+        responses = [m for m in resp if m.msg not in status]
+        if not responses:
+            raise ValueError("No reply from motor.")
+            return
+
+        if len(responses) > 1:
+            warning = [
+                "Multiple messages received:",
+                *responses,
+            ]
+            #warnings.warn("\n  * ".join(warning))
+
+        return responses[-1]
+
+    def rw(self, command: bytes) -> list:
+        """Writes and reads motor controller."""
+        self.w(command)
+        return self.r()
+
+    def pos2deg(self, position: int) -> float:
+        return position * self.min_step
+
+    def deg2pos(self, degree: float) -> int:
+        return round(degree / self.min_step)
+
+    def posdiff(self, target_position, curr_position):
+        """Returns relative move distance based on absolute position."""
+
+        # Normalize
+        target = target_position % self.steps_per_revolution
+        curr = curr_position % self.steps_per_revolution
+
+        # Get smallest rotation
+        diff = target - curr
+        if abs(diff) > self.steps_per_revolution/2:
+            if diff > 0:
+                return diff - self.steps_per_revolution
+            else:
+                return diff + self.steps_per_revolution
+        return diff
+
+    @property
+    def position(self):
+        """Returns absolute position based on encoder value.
+
+        Accurate only after homing. Does not normalize within
+        revolution steps.
+
+        Equivalent representation using encoder_count:
+        `self.rw(apt.mot_req_enccounter()).encoder_count`
+        """
+        offset = self.offset[self.channel]
+        return self.rw(apt.mot_req_poscounter(self._channel)).position - offset
+
+    def is_moving(self) -> bool:
+        """Queries if motor is still rotating."""
+        message = self.rw(apt.mot_req_dcstatusupdate(chan_ident=self._channel))
+        data = self.extract(message, "moving_forward", "moving_reverse")
+        return data.get("moving_forward", False) or data.get("moving_reverse", False)
+
+    def goto(self, ch, position: int = 0):
+        """Move motor to 'position' in units of microsteps."""
+
+        self.w(apt.mot_move_absolute(ch, position))
+
+    def jog(self, ch, direction: int):
+        """Performs a jog based on jog parameters.
+
+        Currently not used, similar functionality to spin.
+
+        Args:
+            direction: 0x01 (forward) or 0x02 (backward)
+        """
+        self.w(apt.mot_move_jog(ch, direction))
+
+    def identify(self):
+        """Blinks LED."""
+        self.w(apt.mod_identify(chan_ident=1))
+
+    @property
+    def enabled(self) -> tuple:
+        """Returns ENABLE state on each individual channel."""
+        states = []
+        for ch in self.CHANNELS:
+            msg = apt.mod_req_chanenablestate(ch)
+            state = self.rw(msg).enabled
+            states.append(state)
+        return tuple(states)
+
+    @enabled.setter
+    def enabled(self, states: tuple):
+        """Sets ENABLE state on each individual channel.
+
+        Disabling of the motor channels is strongly not recommended:
+        setting an angle A when the channel is disabled, and then an
+        angle B when the channel is enabled, results in a fast transition
+        to angle A before the usual gradual transition from A to B.
+        At this point, it is not clear if this is expected, or if this
+        causes unintentional stress to the motor gears.
+
+        Args:
+            states: One of boolean 3-tuple, or a single boolean.
+        """
+        states = self.validate_3tuple(states, bool)
+        ch_ids = sum([(1 << i) for i, state in enumerate(states) if state])
+        self.w(apt.mod_set_chanenablestate(chan_ident=ch_ids, enable_state=0x1))
+
+    @staticmethod
+    def validate_angle(angle):
+        return np.clip(angle, ThorlabsMPC320.MIN_RANGE, ThorlabsMPC320.MAX_RANGE)
+
+    @staticmethod
+    def validate_3tuple(obj, t=None):
+        if hasattr(obj, "__len__"):  # object is already a tuple, TODO: improve this check
+            if len(obj) != 3:
+                raise ValueError(f"Tuple needs to be of length 3.")
+            if t is not None and not all([isinstance(v, t) for v in obj]):
+                raise ValueError(f"Tuple is not of type '{t}': '{obj}'")
+            obj = tuple(obj)
+        else:
+            if t is not None and not isinstance(obj, t):
+                raise ValueError(f"Input is not of type '{t}': '{obj}'")
+            obj = (obj, obj, obj)
+        return obj
+
+    @staticmethod
+    def extract(message, *fields):
+        return { key: getattr(message, key) for key in fields }
+
+
+    ##################
+    #   PARAMETERS   #
+    ##################
+
+    # Units are in microsteps, see 'position()' for details.
+
+    @property
+    def params(self):
+        """Returns parameters used for device
+
+            >>> motor.params_velocity = {"velocity": 15}
+            >>> motor.params_velocity
+            {
+                "velocity": 15, # newly set
+                "home_position": 685,
+                "jog_step1": 25,
+                "jog_step2": 25,
+                "jog_step3": 25,  # see setter defaults
+            }
+        """
+        data = self.rw(apt.pol_req_params())
+        return self.extract(
+            data, "velocity", "home_position", "jog_step1", "jog_step2","jog_step3",
+        )
+
+    @params.setter
+    def params(self, value):
+        settings = {
+            "velocity": 10,
+            "home_position": 685,
+            "jog_step1": 25,
+            "jog_step2": 25,
+            "jog_step3": 25,
+            **value,  # override by value
+        }
+        return self.w(apt.pol_set_params(**settings))
+
+    @property
+    def params_limswitch(self):
+        """Returns limit switch parameters.
+
+        Unknown whether software limit switch is used.
+
+        For the hardware limit switches:
+          - '0x01': ignore switch
+          - '0x02': switch makes on contact
+          - '0x03': switch breaks on contact
+          - '0x04': switch makes on contact (only used for homing)
+          - '0x05': switch breaks on contact (only used for homing)
+        """
+        data = self.rw(apt.mot_req_limswitchparams())
+        return self.extract(
+            data,
+            "cw_hardlimit", "ccw_hardlimit",
+            "cw_softlimit", "ccw_softlimit", "soft_limit_mode",
+        )
+
+    @params_limswitch.setter
+    def params_limswitch(self, value):
+        settings = {
+            "cw_hardlimit": 2,
+            "ccw_hardlimit": 2,
+            "cw_softlimit": 0,
+            "ccw_softlimit": 0,
+            "soft_limit_mode": 1,
+            **value,  # override by value
+        }
+        return self.w(apt.mot_set_limswitchparams(**settings))
+
+class Apt:
+    """
+    See Thorlabs APT protocol specification, page 12, for description of dest and source.
+    Used when messages are broadcasted to sub-modules.
+    In modern systems, typically connect one-to-one COM port connection,
+    so can simply replace all source reference to 0x01 (host) and
+    destination reference to 0x50 (generic USB).
+
+    Source:
+        https://www.thorlabs.com/software/apt/APT_Communications_Protocol_Rev_15.pdf
+    """
+
+    def __getattr__(self, name):
+        """Intercepts calls to and injects apt.functions.
+
+        Calls to every other function in apt is transparently passed
+        through, unless they are defined in apt.functions.
+
+        This monkey patch curries '0x50' as destination byte and
+        '0x01' as source byte, since all apt.functions.[^_]* have them
+        as first and second positional arguments.
+        """
+        target = getattr(_apt, name)  # could have been imported downstream
+        if not hasattr(_apt.functions, name):
+            return target
+
+        # Patch APT function
+        curry = [0x50, 0x01]
+
+        def f(*args, **kwargs):
+            target = getattr(_apt, name)
+            return target(*curry, *args, **kwargs)
+        return f
+
+apt = Apt()  # required
+
+# Quick tests
+if __name__ == "__main__":
+    port = "/dev/serial/by-id/usb-Thorlabs_Polarization_Controller_38418404-if00-port0"
+
+    # Connect to motor
+    motor = ThorlabsMPC320(port, homed=True)
+    motor.identify()                  # blinks LED
+    print("Serial:", motor.identity)  # prints identity information
+
+    # Perform rotations
+    #motor.stop(1)              # stop any existing rotations
+    #motor.home(1)              # go to home, non-blocking
+    #while motor.is_moving():  # wait until homing completed
+        #pass
+
+    # Perform blocking rotations
+    #motor.blocking = True
+    #motor.home(2)              # go to home, blocking
+    #motor.angle = 45          # go to 45 degree position
+    #motor.angle += 45         # go to 90 degree position
+
+    # Perform continuous jog
+    #motor.spin(clockwise=True)  # turn clockwise perpetually, non-blocking
+    #time.sleep(3)
+    #print(motor.angle)          # motor angle after 3 seconds
+    #motor.stop()

--- a/S15qkd/modules/polcomp/paddles/paddlepolcomp.py
+++ b/S15qkd/modules/polcomp/paddles/paddlepolcomp.py
@@ -1,8 +1,125 @@
 #!/usr/bin/env python3
 """Provides the PaddlePolComp class."""
 
+import numpy as np
+from fpfind.lib import parse_epochs as parser
+
+from S15qkd.modules.polcomp import optimizers
 from S15qkd.modules.polcomp.mock.mockpolcomp import ProxyPolComp
+from S15qkd.modules.polcomp.paddles.mpc320 import ThorlabsMPC320
+from S15qkd.qkd_globals import QKDProtocol, logger
+from S15qkd.utils import Process, get_current_epoch
 
 
 class PaddlePolComp(ProxyPolComp):
-    pass
+    """Wraps Thorlabs MPC320 for polarization compensation."""
+
+    ABSOLUTE_BOUND = (ThorlabsMPC320.MIN_RANGE, ThorlabsMPC320.MAX_RANGE)
+    ABSOLUTE_BOUNDS = [ABSOLUTE_BOUND] * 3
+    DEFAULT_ANGLES = (40, 40, 40)
+    MIN_THRESHOLD = 2 * ThorlabsMPC320.MIN_STEP
+
+    def __init__(self, device_path, callback_service_to_BBM92=None):
+        super().__init__(None, callback_service_to_BBM92)
+        self.motor = ThorlabsMPC320(device_path, suppress_errors=True)
+        self.protocol = QKDProtocol.SERVICE
+        self.optimizer = None
+        self.disable_till_protocol_switch = False
+
+        self.load_config()  # single connection ignored
+        curr_conn = Process.config.remote_connection_id
+        print(type(curr_conn), curr_conn)
+        self._refresh_optimizer()
+
+    def save_config(self):
+        """Writes current LCVR voltages to configuration of current connection."""
+        pass
+
+    def load_config(self):  # use 'get' instead
+        self._commit_angles(PaddlePolComp.DEFAULT_ANGLES)
+
+    def send_epoch(self, epoch):
+        # Check for protocol transition
+        if self.protocol != QKDProtocol.SERVICE:
+            self.protocol = QKDProtocol.SERVICE
+            self.disable_till_protocol_switch = False
+            self._refresh_optimizer()
+
+        # Ignore if protocol due for switching
+        if self.disable_till_protocol_switch:
+            return
+
+        # Update QBER only if specified epoch has passed
+        epochint = parser.epoch2int(epoch)
+        if epochint <= self.prev_epochint:
+            logger.debug(
+                f"Ignored epoch {epoch}: "
+                f"waiting for epoch {parser.int2epoch(self.prev_epochint)}"
+            )
+            return
+
+        # Update QBER and handle BBM92 trigger
+        self.qber = self.estimator.handle_epoch(epoch)
+        self._write_qber(self.qber, epoch)
+        if self.qber < self.qber_threshold:
+            self.disable_till_protocol_switch = True
+            self._callback()
+            return
+
+        # Check if angle difference too small => optimization failed
+        angles = self.optimizer(self.qber)
+        logger.debug(
+            f"Adjusting {self.prev_angles} -> {angles} "
+            f"for {self.qber:.3f} QBER @ epoch {epoch}"
+        )
+        dx = np.array(angles) - np.array(self.prev_angles)
+        if np.all(np.abs(dx) < PaddlePolComp.MIN_THRESHOLD):
+            self._refresh_optimizer()
+            angles = self.optimizer(self.qber)
+
+        # Send epochs only after specified epoch has passed
+        self._commit_angles(angles)
+
+    def update_QBER_secure(self, qber, epoch):
+        # Check for protocol transition
+        if self.protocol != QKDProtocol.BBM92:
+            self.protocol = QKDProtocol.BBM92
+            self.disable_till_protocol_switch = False
+            self._refresh_optimizer()
+
+        # Ignore if protocol due for switching
+        if self.disable_till_protocol_switch:
+            return
+
+        # Update QBER
+        super().update_QBER_secure(qber, epoch)
+
+    def _commit_angles(self, angles):
+        self.prev_angles = angles
+        self.motor.angles = angles
+        self.prev_epochint = get_current_epoch()  # motor takes time to rotate
+
+    def _refresh_optimizer(self):
+        """Resets and assigns new optimizer based on current protocol.
+
+        Be careful: this method is full of side-effects, affecting 'optimizer'
+        and 'estimator'.
+        """
+        # Terminates existing optimizations
+        if self.optimizer:
+            self.optimizer(None)  # graceful connection close
+            self.optimizer = None
+
+        # Restart QBER calculation
+        self.estimator.reset()
+
+        # Create new optimizer
+        kwargs = {
+            "x0": self.motor.angles,  # start from current position
+            "step": 80 if self.protocol is QKDProtocol.SERVICE else 30,
+            "bounds": PaddlePolComp.ABSOLUTE_BOUNDS,
+        }
+        self.optimizer = optimizers.run_manual_optimizer(
+            optimizers.minimize_neldermead,
+            kwargs=kwargs,
+        )

--- a/S15qkd/modules/polcomp/paddles/paddlepolcomp.py
+++ b/S15qkd/modules/polcomp/paddles/paddlepolcomp.py
@@ -1,0 +1,8 @@
+#!/usr/bin/env python3
+"""Provides the PaddlePolComp class."""
+
+from S15qkd.modules.polcomp.paddles.mpc320 import ThorlabsMPC320
+from S15qkd.modules.polcomp.mock.mockpolcomp import MockPolComp
+
+class PaddlePolComp(MockPolComp):
+    pass

--- a/S15qkd/modules/polcomp/paddles/paddlepolcomp.py
+++ b/S15qkd/modules/polcomp/paddles/paddlepolcomp.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 """Provides the PaddlePolComp class."""
 
-from S15qkd.modules.polcomp.paddles.mpc320 import ThorlabsMPC320
-from S15qkd.modules.polcomp.mock.mockpolcomp import MockPolComp
+from S15qkd.modules.polcomp.mock.mockpolcomp import ProxyPolComp
 
-class PaddlePolComp(MockPolComp):
+
+class PaddlePolComp(ProxyPolComp):
     pass

--- a/S15qkd/modules/polcomp/qber_estimator.py
+++ b/S15qkd/modules/polcomp/qber_estimator.py
@@ -25,7 +25,7 @@ class QberEstimator:
         self.diagnoses = []
 
     def handle_epoch(self, epoch) -> float:
-        epoch_path = FoldersQKD.RAWKEYS + '/' + epoch
+        epoch_path = FoldersQKD.RAWKEYS + "/" + epoch
         return self.handle_epoch_path(epoch_path)
 
     def handle_epoch_path(self, epoch_path) -> float:
@@ -49,7 +49,9 @@ class QberEstimator:
         coinc_matrix = np.sum(matrices, axis=0)
         er_coin = sum(coinc_matrix[[0, 5, 10, 15]])  # VV, AA, HH, DD
         gd_coin = sum(coinc_matrix[[2, 7, 8, 13]])  # VH, AD, HV, DA
-        qber = round(er_coin / (er_coin + gd_coin), 3) if er_coin + gd_coin != 0 else 1.0
+        qber = (
+            round(er_coin / (er_coin + gd_coin), 3) if er_coin + gd_coin != 0 else 1.0
+        )
         logger.info(f"Avg(qber): {qber:.2f} of the last {self.accumulated_bits} bits.")
         return qber
 
@@ -58,7 +60,7 @@ class QberEstimator:
             return 4000
         if qber < 0.15:
             return 1000
-        if qber < 0.3:
+        if qber < 0.30:
             return 800
         else:
             return 400

--- a/S15qkd/modules/polcomp/qber_estimator.py
+++ b/S15qkd/modules/polcomp/qber_estimator.py
@@ -2,8 +2,8 @@
 
 import numpy as np
 
+from S15qkd.qkd_globals import FoldersQKD, logger
 from S15qkd.utils import service_T3
-from S15qkd.qkd_globals import logger, FoldersQKD
 
 
 class QberEstimator:
@@ -36,7 +36,8 @@ class QberEstimator:
         self.diagnoses.append(diagnosis)
         self.accumulated_bits += diagnosis.okcount
         logger.info(
-            f"Accumulating bits for QBER calculation: {self.accumulated_bits} / {self.desired_bits}"
+            "Accumulating bits for QBER calculation: "
+            f"{self.accumulated_bits} / {self.desired_bits}"
         )
         if self.accumulated_bits >= self.desired_bits:
             self.qber = self.calculate_qber()

--- a/S15qkd/modules/polcomp/qber_estimator.py
+++ b/S15qkd/modules/polcomp/qber_estimator.py
@@ -2,8 +2,8 @@
 
 import numpy as np
 
-from .utils import service_T3
-from .qkd_globals import logger, FoldersQKD
+from S15qkd.utils import service_T3
+from S15qkd.qkd_globals import logger, FoldersQKD
 
 
 class QberEstimator:

--- a/S15qkd/modules/polcomp/qber_estimator.py
+++ b/S15qkd/modules/polcomp/qber_estimator.py
@@ -69,7 +69,7 @@ class QberEstimator:
         gd_coin = sum(coinc_matrix[[2, 7, 8, 13]])  # VH, AD, HV, DA
         tt_coin = er_coin + gd_coin
         qber = round(er_coin / tt_coin, 3) if tt_coin != 0 else 1.0
-        logger.info(f"Avg(qber): {qber:.2f} of the last {tt_coin} bits.")
+        logger.info(f"Avg(QBER): {qber:.3f} of the last {tt_coin} bits.")
         return qber, tt_coin
 
     def _get_desired_bits(self, qber) -> int:

--- a/S15qkd/polarization_compensation.py
+++ b/S15qkd/polarization_compensation.py
@@ -46,11 +46,10 @@ from typing import Tuple, NamedTuple, Any
 from dataclasses import dataclass
 
 from S15lib.instruments.lcr_driver import LCRDriver, MockLCRDriver
-from .utils import HeadT1, ServiceT3, service_T3
-from . import qkd_globals
-from .qkd_globals import logger, FoldersQKD
-from .utils import Process
-from .qber_estimator import QberEstimator
+from S15qkd import qkd_globals
+from S15qkd.qkd_globals import logger, FoldersQKD
+from S15qkd.modules.polcomp.qber_estimator import QberEstimator
+from S15qkd.utils import HeadT1, ServiceT3, service_T3, Process
 
 VOLT_MIN = 0.9
 VOLT_MAX = 5.5

--- a/S15qkd/polarization_compensation.py
+++ b/S15qkd/polarization_compensation.py
@@ -50,6 +50,7 @@ from .utils import HeadT1, ServiceT3, service_T3
 from . import qkd_globals
 from .qkd_globals import logger, FoldersQKD
 from .utils import Process
+from .qber_estimator import QberEstimator
 
 VOLT_MIN = 0.9
 VOLT_MAX = 5.5
@@ -643,112 +644,69 @@ class PolComp(object):
 
 
 class MockPolComp:
-    """Enumerates interface exposed to Controller.
+    """Enumerates interface exposed to Controller."""
 
-    Does no actual polarization compensation, but instead monitors and writes out
-    to file at 'QBER_READOUT_PATH' for external service to handle.
-    """
+    READOUT_FILE = "/tmp/cryptostuff/mockpolcomp_qber_epoch.txt"
 
-    QBER_READOUT_PATH = "/tmp/cryptostuff/mockpolcomp_qber_epoch.txt"
-
-    #==========  PUBLIC METHODS  ==========
-
-    def __init__(self, lcr_path, callback_service_to_BBM92=None):  # Controller::__init__
-        self.lcr = MockLCRDriver(lcr_path)  # Controller::update_config
-        self.set_voltage = [0, 0, 0, 0]  # Controller::reload_configuration
-        self.last_voltage_list = self.set_voltage.copy()  # Controller::reload_configuration
+    def __init__(self, lcr_path, callback_service_to_BBM92=None):  # Controller.__init__()
         self._callback = callback_service_to_BBM92
-        self._last_qber = 1
-        self.averaging_n = 2000
-        self.qber_counter = 0
-        self.qber_list = []
+        self.estimator = QberEstimator()
+        self.qber = self.estimator.qber
         self.qber_threshold = qkd_globals.config['QBER_threshold']
 
-    def _set_voltage(self):  # Controller::reload_configuration
-        """Commits voltages."""
-        (
-            self.lcr.V1,
-            self.lcr.V2,
-            self.lcr.V3,
-            self.lcr.V4,
-        ) = self.set_voltage
+    def send_epoch(self, epoch):  # Controller.send_epoch_notification()
+        """Process notification of epoch provided by costream/splicer.
 
-    def send_epoch(self, epoch_path):  # Controller::send_epoch_notification
-        """Responsible for extracting QBER and calling SERVICE->BBM92.
-
-        SERVICE mode only.
+        Responsible for extracting QBER and calling SERVICE->BBM92.
         """
-        epoch = epoch_path.split('/')[-1]
-        self.update_QBER_from_diagnosis(
-            self.find_diagnosis_from_epoch(epoch_path),
-            self.qber_threshold,
-            epoch,
-        )
+        self.qber = self.estimator.handle_epoch(epoch)
+        self._write_qber(self.qber, epoch)
+        if self.qber < self.qber_threshold:
+            self._callback()
 
-    def update_QBER_secure(self, qber, epoch):  # Controller::drift_secure_comp
-        """
-        BBM92 mode only.
-        """
-        self._last_qber = qber
-        self._write_qber_epoch(qber, epoch)
+    def update_QBER_secure(self, qber, epoch):  # Controller.drift_secure_comp()
+        """Process notification of QBER @ epoch provided by error correction.
 
-    def do_walks(self):  # Controller::pol_com_walk
+        Direct counterpart to PolComp.send_epoch().
+        """
+        self.qber = qber
+        self._write_qber(qber, epoch)
+
+    def start_walk(self):  # Controller.pol_com_walk()
+        pass
+
+    def save_config(self):  # Controller.reload_configuration()
+        pass
+
+    def load_config(self):  # Controller.reload_configuration()
         pass
 
     @property
-    def last_qber(self) -> float:  # Controller::get_status_info
-        return self._last_qber
+    def last_qber(self) -> float:  # Controller.get_status_info()
+        return self.qber
 
-
-    #==========  INTERNAL METHODS  ==========
-
-    def _write_qber_epoch(self, qber, epoch):
-        with open(self.QBER_READOUT_PATH, "w") as f:
+    def _write_qber(self, qber, epoch):
+        """Writes QBER and corresponding epoch to temporary file for message passing."""
+        with open(MockPolComp.READOUT_FILE, "w") as f:
             f.write(f"{qber} {epoch}")
 
-    def find_diagnosis_from_epoch(self, epoch_path):
-        diagnosis = service_T3(epoch_path)
-        return diagnosis
+    def _read_qber(self):
+        with open(MockPolComp.READOUT_FILE) as f:
+            data = f.read()
+        qber, epoch = data.strip().split(" ")
+        qber = float(qber)
+        return qber, epoch
 
-    def update_QBER_from_diagnosis(self, diagnosis, qber_threshold: float = 0.085, epoch: str = None):
-        self.qber_counter += 1
-        if self.qber_counter < 10: # in case pfind finds a bad match, we don't want to change the lcvr voltage too early
-            return
-
-        self.qber_list.append(diagnosis)
-        total_bits = sum([d.okcount for d in self.qber_list])
-        logger.info("Accumulating bits for QBER calculation: %d / %d", total_bits, self.averaging_n)
-        if total_bits >= self.averaging_n:
-
-            # Compute QBER from set of diagnosis in each epoch
-            matrices = np.array([d.coinc_matrix for d in self.qber_list])
-            coinc_matrix = np.sum(matrices, axis=0)
-            er_coin = sum(coinc_matrix[[0, 5, 10, 15]])  # VV, AA, HH, DD
-            gd_coin = sum(coinc_matrix[[2, 7, 8, 13]])  # VH, AD, HV, DA
-            if er_coin + gd_coin == 0:
-                qber_mean = 1.0
-            else:
-                qber_mean = round(er_coin / (er_coin + gd_coin), 3)
-
-            self.qber_list.clear()
-            logger.info(
-                f'Avg(qber): {qber_mean:.2f} of the last {total_bits} bits.')
-
-            qber = qber_mean
-            self._last_qber = qber
-            self._write_qber_epoch(qber, epoch)
-
-            if qber_mean > 0.3:
-                self.averaging_n = 400
-            if qber_mean < 0.3:
-                self.averaging_n = 800
-            if qber_mean < 0.15:
-                self.averaging_n = 1000
-            if qber_mean < 0.12:
-                self.averaging_n = 4000
-            if qber_mean < qber_threshold:
-                self._callback()
-                return
+    def _read_qber_after(epoch):
+        """Monitors and returns the QBER after specified epoch."""
+        from fpfind.lib import parse_epochs as parser
+        epochint = parser.epoch2int(epoch)
+        while True:
+            qber, _epoch = self._read_qber()
+            _epochint = parser.epoch2int(_epoch)
+            if _epochint > epochint:
+                return qber
+            time.sleep(0.5)  # wait for next epoch
 
 
 class PaddlePolComp(MockPolComp):

--- a/S15qkd/qber_estimator.py
+++ b/S15qkd/qber_estimator.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+
+import numpy as np
+
+from .utils import service_T3
+from .qkd_globals import logger, FoldersQKD
+
+
+class QberEstimator:
+    """Provides an estimation of QBER depending on the available bits.
+
+    Note:
+        Note that this class is not thread-safe, but should work under the assumption
+        that QBER computation should take much less than the epoch separation time, i.e.
+        0.536s. If thread-safety is desired, one could use 'threading.Lock'.
+    """
+
+    def __init__(self):
+        self.qber = 1.0
+        self.reset()
+
+    def reset(self, desired_bits: int = 0):
+        self.desired_bits = desired_bits
+        self.accumulated_bits = 0
+        self.diagnoses = []
+
+    def handle_epoch(self, epoch) -> float:
+        epoch_path = FoldersQKD.RAWKEYS + '/' + epoch
+        return self.handle_epoch_path(epoch_path)
+
+    def handle_epoch_path(self, epoch_path) -> float:
+        diagnosis = service_T3(epoch_path)
+        return self.handle_diagnosis(diagnosis)
+
+    def handle_diagnosis(self, diagnosis) -> float:
+        self.diagnoses.append(diagnosis)
+        self.accumulated_bits += diagnosis.okcount
+        logger.info(
+            f"Accumulating bits for QBER calculation: {self.accumulated_bits} / {self.desired_bits}"
+        )
+        if self.accumulated_bits >= self.desired_bits:
+            self.qber = self.calculate_qber()
+            self.reset(self._get_desired_bits(self.qber))
+        return self.qber
+
+    def calculate_qber(self) -> float:
+        # Compute QBER from set of diagnosis in each epoch
+        matrices = np.array([d.coinc_matrix for d in self.diagnoses])
+        coinc_matrix = np.sum(matrices, axis=0)
+        er_coin = sum(coinc_matrix[[0, 5, 10, 15]])  # VV, AA, HH, DD
+        gd_coin = sum(coinc_matrix[[2, 7, 8, 13]])  # VH, AD, HV, DA
+        qber = round(er_coin / (er_coin + gd_coin), 3) if er_coin + gd_coin != 0 else 1.0
+        logger.info(f"Avg(qber): {qber:.2f} of the last {self.accumulated_bits} bits.")
+        return qber
+
+    def _get_desired_bits(self, qber) -> int:
+        if qber < 0.12:
+            return 4000
+        if qber < 0.15:
+            return 1000
+        if qber < 0.3:
+            return 800
+        else:
+            return 400

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,13 @@
+[lint]
+# Choose from list of rules: <https://docs.astral.sh/ruff/rules/>
+select = [
+    "E", "W",  # PEP8 code styles
+    "I",       # isort
+    "F",       # pyflakes
+    "PL",      # pylint
+    "Q",       # flake8-quotes
+    "C90",     # code complexity
+]
+ignore = [
+    "PLR2004",  # magic constants
+]


### PR DESCRIPTION
New features:
* QBER estimation is provided as a standalone module, with dynamic adjustment of required number of bits to optimize calculation.
* Optimization is performed using the Nelder-Mead algorithm, using `scipy` implementation.
* Use of the motorised fiber paddles MPC320 for polarization compensation can now be enabled using the `use_mpc320_device` field under the new configuration nesting format (i.e. `qcrypto.polarization_compensation`). Default remains the LCR device for compensation.
  * The device path overloads that used already by the LCR, i.e. `LCR_polarization_compensator_path`
  * The MPC320 wrapper class has been brought in, with a slightly different interface exposed from existing scripts.
* Angles are cached during configuration change, as per previous LCR implementation.


Repository cleanup:
* Introduced some repository nesting to compartmentalise components, to avoid bloating the individual modules. Currently added a `S15qkd/modules/polcomp` directory, with folders containing the respective polarization compensation implementations, and common modules like optimizations and QBER estimation.
* Added new linting rules using Ruff (only for the new components introduced in this PR, to eventually rollout to the rest of the repo as well)

Should not have any side-effects on existing deployments.